### PR TITLE
BLAIS5-4086: upgrade nodejs runtime to 20 due as nodejs12 has passed end of support

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,5 @@
 service: default
-runtime: nodejs12
+runtime: nodejs20
 
 basic_scaling:
   idle_timeout: 60s


### PR DESCRIPTION
GCP support schedule:
https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule#nodejs